### PR TITLE
Use ppxlib's public API instead of its private one

### DIFF
--- a/camlp5/core2.ml
+++ b/camlp5/core2.ml
@@ -13,8 +13,7 @@ let get_val loc = function
 | _       -> failwith "could not get VaVal _ (should not happen)"
 
 
-module Migr =
-  Ppxlib_ast__Versions.Convert(Ppxlib_ast__Versions.OCaml_current)(Ppxlib.Import_for_core.Js)
+module Migr = Ppxlib_ast.Selected_ast.Of_ocaml
 
 open GTCommon
 


### PR DESCRIPTION
With the last ppxlib release, `Import_for_core` was removed from the API. I've just had a quick glimpse at the one line where it was used in `GT` (which also uses ppxlib's private API `Ppxlib_ast__Versions`) and on the first sight it seems like it can just be removed by the standard module for conversions `Selected_ast`. I haven't even tried to build it like that though, so it would be good to review this well. 