### PR TITLE
Improve support of mutually recursive types

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,11 +1,19 @@
-name: Build master
+name: Build master in docker
 
 on:
-  push:
-    paths-ignore:
-      - 'README.md'
+  pull_request:
     branches:
       - 'master'
+  push:
+    branches:
+      - 'master'
+    paths-ignore:
+      - 'README.md'
+
+env:
+  OPAMROOT: /home/opam/.opam
+  OPAMYES: true
+  GT_WITH_DOCS: yes
 
 jobs:
   build:
@@ -13,44 +21,34 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
-        ocaml-compiler:
-          - ocaml-base-compiler.4.14.1
-
-    env:
-      GT_WITH_DOCS: yes
+          - ubuntu-latest
 
     runs-on: ${{ matrix.os }}
+    container:
+      image: ocaml/opam:ubuntu-lts-ocaml-4.14
+      options: --user root               # dirty hack
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Retrieve date for cache key
-        id: cache-key
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-        shell: bash
-
-      - name: Restore opam cache
-        id: opam-cache
-        uses: actions/cache@v2
-        with:
-          path: "~/.opam"
-          # invalidate cache daily, gets built daily using a scheduled job
-          key: ${{ steps.cache-key.outputs.date }}
-
-      - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-
-      #- run: opam pin add GT . --no-action
-      - run: opam depext --yes --with-test
+      - run: |
+          git config --global --add safe.directory /__w/GT/GT
+          git submodule update --init
+      - run: opam pin add GT . --no-action
+      - run: opam depext GT --yes #--with-test
 
       - name: Install dependecies for documentation
-        run: opam install odoc pa_ppx --yes
+        run: |
+          sudo apt-get install pkg-config -y
+          opam install odoc pa_ppx --yes
 
-      - run: opam install . --deps-only --with-test
+      - run: opam install . --deps-only #--with-test
       - run: opam exec -- dune build  --profile=release
       - run: opam exec -- dune test   --profile=release
 
@@ -71,3 +69,13 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_build/default/_doc/_html
+
+      - name: Send coverage report to Coveralls
+        run: |
+          #git config --global --add safe.directory /__w/zanuda/zanuda
+          opam exec -- make coverage
+          opam exec -- bisect-ppx-report send-to Coveralls --coverage-path $BISECT_DIR
+        env:
+          BISECT_DIR: /tmp/GTcov
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ Makefile
 /qtc-GT.*
 
 *.install
-
+_coverage

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- Upgrade support of mutually recursive abbreviations (in presence of -rectypes). Previously some code would not compile (breaking)
+- Mutually recursive fixpoint on N typs is now called 'fix_typ1_typ2_..._typN' instead of 'fix_typ1' (breaking)
 - Add forgotten `html` plugin to `GT.ppx_all` findlib package
 - Replace dependecy on base by a dependecy on Ppxlib.stdppx
 - Support both `[@@deriving gt ~options:{...}]` and `[@@deriving gt ~plugins:{...}]`

--- a/GT.opam
+++ b/GT.opam
@@ -28,6 +28,7 @@ depends: [
   "ocamlgraph"
   "logger-p5"
   "ppx_inline_test"
+  "bisect_ppx"
   "ocaml" {>= "4.13"}
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "camlp5" {>= "8.00.02"}

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,13 @@ install:
 uninstall:
 	dune build @install $(DFLAGS)
 	dune uninstall $(DFLAGS)
+
+.PHONY: coverage
+TEST_COV_D = /tmp/GTcov
+coverage:
+	if [ -d $(TEST_COV_D) ]; then $(RM) -r $(TEST_COV_D); fi
+	mkdir -p $(TEST_COV_D)
+	BISECT_FILE=$(TEST_COV_D)/zanuda dune runtest --no-print-directory \
+		--instrument-with bisect_ppx --force
+	bisect-ppx-report html --coverage-path $(TEST_COV_D) #--expect src/
+	bisect-ppx-report summary --coverage-path $(TEST_COV_D) #--expect src/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [1]:  https://github.com/JetBrains-Research/GT/actions/workflows/master.yml/badge.svg?branch=master
 [2]:  https://github.com/JetBrains-Research/GT/actions/workflows/master.yml
 
+[![Coverage Status](https://coveralls.io/repos/github/PLTools/GT/badge.svg?branch=master)](https://coveralls.io/github/PLTools/GT?branch=master)
+
 # Datatype-generic object-oriented transformations for OCaml (a.k.a. GT)
 
 This library implements a framework for datatype-generic programming in Objective Caml language.

--- a/camlp5/Camlp5Helpers.ml
+++ b/camlp5/Camlp5Helpers.ml
@@ -142,6 +142,7 @@ module Exp = struct
     | "[]" | "::" | _ when HelpersBase.Char.is_alpha s.[0] && capitalized s -> <:expr< $uid:s$ >>
     | _ -> <:expr< $lid:s$ >>
 
+  let attribute _ e = e 
   let unit ~loc =  <:expr< () >>
   let sprintf ~loc fmt =
     Printf.ksprintf (fun s -> <:expr< $lid:s$ >>) fmt

--- a/camlp5/dune
+++ b/camlp5/dune
@@ -40,7 +40,7 @@
    -package
    camlp5,camlp5.pa_o,camlp5.pr_dump,camlp5.extend,camlp5.quotations,logger,ppxlib,ocamlgraph
    -package
-   ppx_inline_test.runtime-lib
+   ppx_inline_test.runtime-lib,bisect_ppx.common,bisect_ppx.runtime
    -I
    ../common
    %{read-lines:../config/package-doc.cfg}
@@ -95,7 +95,7 @@
    -package
    logger,ppxlib,ocamlgraph
    -package
-   ppx_inline_test.runtime-lib
+   ppx_inline_test.runtime-lib,bisect_ppx.common,bisect_ppx.runtime
    %{read-lines:../config/package-doc.cfg}
    %{cmas}
    -o

--- a/common/GTHELPERS_sig.ml
+++ b/common/GTHELPERS_sig.ml
@@ -89,6 +89,7 @@ module type S = sig
 
     (* val new_type: loc:loc -> string -> t -> t *)
     val constraint_ : loc:loc -> t -> Typ.t -> t
+    val attribute : Ppxlib.attribute -> t -> t
   end
 
   and Typ : sig

--- a/common/dune
+++ b/common/dune
@@ -13,6 +13,8 @@
  (flags
   (:standard -w -32-9 -warn-error -A))
  ;(inline_tests)
+ (instrumentation
+  (backend bisect_ppx))
  (preprocess
   (pps
    ppx_inline_test

--- a/common/expander.ml
+++ b/common/expander.ml
@@ -52,7 +52,7 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
              case
                ~lhs:
                  (Pat.constr_record ~loc cd.pcd_name.txt
-                 @@ List.map2_exn ls names ~f:(fun l s -> l.pld_name.txt, Pat.var ~loc s)
+                  @@ List.map2_exn ls names ~f:(fun l s -> l.pld_name.txt, Pat.var ~loc s)
                  )
                ~rhs:(make_rhs cd names)
            | Pcstr_tuple args ->
@@ -115,11 +115,11 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
      2 + 3*params_count + 1 (for polyvar subtyping)
   *)
     (List.concat
-    @@ map_type_param_names params ~f:(fun s ->
-         [ named_type_arg ~loc ("i" ^ s)
-         ; named_type_arg ~loc s
-         ; named_type_arg ~loc ("s" ^ s)
-         ]))
+     @@ map_type_param_names params ~f:(fun s ->
+          [ named_type_arg ~loc ("i" ^ s)
+          ; named_type_arg ~loc s
+          ; named_type_arg ~loc ("s" ^ s)
+          ]))
     @ [ named_type_arg ~loc "inh"
       ; named_type_arg ~loc Naming.extra_param_name
       ; named_type_arg ~loc "syn"
@@ -157,10 +157,10 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
         (* almost the same as plugin#get_class_sig*)
         k
           [ (Ctf.method_ ~loc (Naming.meth_name_for_record tdecl) ~virt:true
-            @@ Typ.chain_arrow ~loc
-            @@
-            let open Typ in
-            [ var ~loc "inh"; use_tdecl tdecl; var ~loc "syn" ])
+             @@ Typ.chain_arrow ~loc
+             @@
+             let open Typ in
+             [ var ~loc "inh"; use_tdecl tdecl; var ~loc "syn" ])
           ])
       ~onabstract:(fun () ->
         (* For purely abstract type we can only generate interface
@@ -313,9 +313,9 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
       ~onrecord:(fun _ ->
         ans
           [ (Cf.method_virtual ~loc (sprintf "do_%s" tdecl.ptype_name.txt)
-            @@ Typ.(
-                 arrow ~loc (var ~loc "inh")
-                 @@ arrow ~loc (use_tdecl tdecl) (var ~loc "syn")))
+             @@ Typ.(
+                  arrow ~loc (var ~loc "inh")
+                  @@ arrow ~loc (use_tdecl tdecl) (var ~loc "syn")))
           ])
       ~onvariant:(fun cds -> ans @@ List.map cds ~f:on_constructor)
       ~onmanifest:(fun typ ->
@@ -357,10 +357,10 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
                     | Rtag (lab, _, []) ->
                       let methname = sprintf "c_%s" lab.txt in
                       [ (Cf.method_virtual ~loc methname
-                        @@ Typ.(
-                             var ~loc "syn"
-                             |> arrow ~loc @@ var ~loc "extra"
-                             |> arrow ~loc (var ~loc "inh")))
+                         @@ Typ.(
+                              var ~loc "syn"
+                              |> arrow ~loc @@ var ~loc "extra"
+                              |> arrow ~loc (var ~loc "inh")))
                       ]
                     | Rtag (lab, _, [ typ ]) ->
                       (* print_endline "HERE"; *)
@@ -371,12 +371,12 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
                       in
                       let methname = sprintf "c_%s" lab.txt in
                       [ (Cf.method_virtual ~loc methname
-                        @@
-                        let open Typ in
-                        List.fold_right args ~init:(var ~loc "syn") ~f:(fun t ->
-                          arrow ~loc (from_caml t))
-                        |> arrow ~loc @@ var ~loc "extra"
-                        |> arrow ~loc (var ~loc "inh"))
+                         @@
+                         let open Typ in
+                         List.fold_right args ~init:(var ~loc "syn") ~f:(fun t ->
+                           arrow ~loc (from_caml t))
+                         |> arrow ~loc @@ var ~loc "extra"
+                         |> arrow ~loc (var ~loc "inh"))
                       ]
                     | Rtag (_, _, _) -> failwith "Can't deal with conjunctive types"
                     | Rinherit typ ->
@@ -467,13 +467,13 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
                 ~loc
                 (Lident (class_name_for_typ tdecl.ptype_name.txt))
                 (List.concat params
-                @ Typ.
-                    [ var ~loc "inh"
-                    ; openize_poly ~loc
-                      @@ Typ.constr ~loc (Lident tdecl.ptype_name.txt)
-                      @@ map_type_param_names tdecl.ptype_params ~f:(Typ.var ~loc)
-                    ; var ~loc "syn"
-                    ])
+                 @ Typ.
+                     [ var ~loc "inh"
+                     ; openize_poly ~loc
+                       @@ Typ.constr ~loc (Lident tdecl.ptype_name.txt)
+                       @@ map_type_param_names tdecl.ptype_params ~f:(Typ.var ~loc)
+                     ; var ~loc "syn"
+                     ])
             | Ptyp_tuple ts -> helper @@ constr_of_tuple ~loc:t.ptyp_loc ts
             | _ -> failwith "Unsupported case during generate of the type of gcata"
           in
@@ -592,11 +592,11 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
                      ~init:(Exp.send ~loc (Exp.ident ~loc "tr") ("c_" ^ cname.txt))
                      ~f:(Exp.app ~loc)
                      (Exp.ident ~loc "inh"
-                     :: match_and_openize
-                          ~loc
-                          (Exp.ident ~loc subj_s)
-                          (Lident tdecl.ptype_name.txt)
-                     :: List.map ~f:(fun (s, _) -> Exp.ident ~loc s) names))
+                      :: match_and_openize
+                           ~loc
+                           (Exp.ident ~loc subj_s)
+                           (Lident tdecl.ptype_name.txt)
+                      :: List.map ~f:(fun (s, _) -> Exp.ident ~loc s) names))
                  ~onlabel:(fun label patname -> failwith "not implemented")
                  ~oninherit:(fun params cident patname ->
                    Exp.app_list
@@ -652,22 +652,22 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
     (* The pack itself *)
     let gcata_ident = Exp.sprintf ~loc "gcata_%s" tname in
     (Str.single_value ~loc (Pat.sprintf ~loc "%s" tname)
-    @@ Exp.record
-         ~loc
-         [ Ldot (lident "GT", "gcata"), gcata_ident
-         ; ( Ldot (lident "GT", "fix")
-           , if List.length all_tdecls > 1
-             then Exp.sprintf ~loc "%s" @@ Naming.make_fix_name all_tdecls
-             else
-               Exp.fun_ ~loc (Pat.var ~loc "eta")
-               @@ Exp.app_list
-                    ~loc
-                    (Exp.of_longident ~loc (Ldot (Lident "GT", "transform_gc")))
-                    [ gcata_ident; Exp.sprintf ~loc "eta" ] )
-         ; ( Ldot (lident "GT", "plugins")
-           , Exp.object_ ~loc
-             @@ class_structure ~self:(Pat.any ~loc) ~fields:plugin_fields )
-         ])
+     @@ Exp.record
+          ~loc
+          [ Ldot (lident "GT", "gcata"), gcata_ident
+          ; ( Ldot (lident "GT", "fix")
+            , if List.length all_tdecls > 1
+              then Exp.sprintf ~loc "%s" @@ Naming.make_fix_name all_tdecls
+              else
+                Exp.fun_ ~loc (Pat.var ~loc "eta")
+                @@ Exp.app_list
+                     ~loc
+                     (Exp.of_longident ~loc (Ldot (Lident "GT", "transform_gc")))
+                     [ gcata_ident; Exp.sprintf ~loc "eta" ] )
+          ; ( Ldot (lident "GT", "plugins")
+            , Exp.object_ ~loc
+              @@ class_structure ~self:(Pat.any ~loc) ~fields:plugin_fields )
+          ])
     :: List.filter_map plugins ~f:(fun p ->
          (* also we generate transformation function with unit preapplied
          Because we seems to need them in case of abstract type in the interface
@@ -777,6 +777,11 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
       ]
   ;;
 
+  let sort_decls =
+    List.sort ~cmp:(fun { ptype_name = { txt = l } } { ptype_name = { txt = r } } ->
+      String.compare l r)
+  ;;
+
   let fix_typ ~loc tdecls =
     let idx = ref 0 in
     let next () =
@@ -786,42 +791,83 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
     let arr3 a b c = Typ.arrow ~loc a (Typ.arrow ~loc b c) in
     let tup ~loc xs =
       match xs with
-      | [] -> failwith "bad arguemnt"
+      | [] -> failwith "bad argument"
       | [ x ] -> x
       | xs -> Typ.tuple ~loc xs
     in
-    let ys =
-      List.map tdecls ~f:(fun tdecl ->
-        let ps = List.map tdecl.ptype_params ~f:(fun _ -> sprintf "a%d" (next ())) in
-        let subj_t =
-          Typ.constr ~loc (Lident tdecl.ptype_name.txt) @@ List.map ps ~f:(Typ.var ~loc)
+    match tdecls with
+    | [] -> failwith "should not happen"
+    | [ tdecl ] ->
+      (* Single definition is simple *)
+      (* TODO: Maybe we can reuse creation of gcata's signature  *)
+      (* TODO: merge common parts with next general case  *)
+      let ps = map_type_param_names tdecl.ptype_params ~f:Fun.id in
+      let subj_t =
+        Typ.constr ~loc (Lident tdecl.ptype_name.txt) @@ List.map ps ~f:(Typ.var ~loc)
+      in
+      let main_inh = Typ.var ~loc @@ sprintf "inh%d" (next ()) in
+      let main_syn = Typ.var ~loc @@ sprintf "syn%d" (next ()) in
+      let trf = arr3 main_inh subj_t main_syn in
+      let fixpoint =
+        let self_typ =
+          Typ.constr ~loc (Lident tdecl.ptype_name.txt)
+          @@ map_type_param_names tdecl.ptype_params ~f:(Typ.var ~loc)
         in
-        let inhs = List.map ps ~f:(sprintf "%s_i") in
-        let syns = List.map ps ~f:(sprintf "%s_s") in
-        let main_inh = Typ.var ~loc @@ sprintf "inh%d" (next ()) in
-        let main_syn = Typ.var ~loc @@ sprintf "syn%d" (next ()) in
-        let cls =
-          let args =
-            List.map3_exn inhs ps syns ~f:(fun i p s -> [ i; p; s ])
-            |> List.concat
-            |> List.map ~f:(Typ.var ~loc)
-            |> fun xs ->
-            xs
-            @ [ main_inh
-              ; (if is_polyvariant_tdecl tdecl then openize_poly ~loc else id) subj_t
-              ; main_syn
-              ]
+        let class_ =
+          Typ.class_
+            ~loc
+            (Lident (class_name_for_typ tdecl.ptype_name.txt))
+            (List.concat_map ps ~f:(fun s -> [ main_inh; Typ.var ~loc s; main_syn ])
+             @ [ main_inh; (*openize_poly ~loc @@*) self_typ; main_syn ])
+        in
+        Typ.arrow ~loc (arr3 main_inh self_typ main_syn) class_
+      in
+      Typ.chain_arrow ~loc [ fixpoint; trf ]
+    | tdecls ->
+      let ys =
+        List.map tdecls ~f:(fun tdecl ->
+          let ps = List.map tdecl.ptype_params ~f:(fun _ -> sprintf "a%d" (next ())) in
+          let subj_t =
+            Typ.constr ~loc (Lident tdecl.ptype_name.txt) @@ List.map ps ~f:(Typ.var ~loc)
           in
-          Typ.class_ ~loc (Lident (Naming.class_name_for_typ tdecl.ptype_name.txt)) args
-        in
-        let trf = arr3 main_inh subj_t main_syn in
-        trf, cls)
-    in
-    let mutuals = tup ~loc @@ List.map ys ~f:fst in
-    List.fold_right
-      ~init:(tup ~loc @@ List.map ys ~f:fst)
-      ys
-      ~f:(fun (_trf, cls) acc -> Typ.arrow ~loc (Typ.arrow ~loc mutuals cls) acc)
+          let inhs = List.map ps ~f:(sprintf "%s_i") in
+          let syns = List.map ps ~f:(sprintf "%s_s") in
+          let main_inh = Typ.var ~loc @@ sprintf "inh%d" (next ()) in
+          let main_syn = Typ.var ~loc @@ sprintf "syn%d" (next ()) in
+          let cls =
+            let args =
+              List.map3_exn inhs ps syns ~f:(fun i p s -> [ i; p; s ])
+              |> List.concat
+              |> List.map ~f:(Typ.var ~loc)
+              |> fun xs ->
+              xs
+              @ [ main_inh
+                ; (if is_polyvariant_tdecl tdecl then openize_poly ~loc else id) subj_t
+                ; main_syn
+                ]
+            in
+            Typ.class_ ~loc (Lident (Naming.class_name_for_typ tdecl.ptype_name.txt)) args
+          in
+          let add_trf x =
+            List.map3_exn inhs ps syns ~f:(fun i p s ->
+              Typ.var ~loc i, Typ.var ~loc p, Typ.var ~loc s)
+            |> List.fold_right
+                 ~f:(fun (i, p, s) acc -> Typ.arrow ~loc (arr3 i p s) acc)
+                 ~init:x
+          in
+          ( sprintf "alias_for_%s" tdecl.ptype_name.txt
+          , add_trf (arr3 main_inh subj_t main_syn)
+          , add_trf cls ))
+      in
+      let fix_arg =
+        tup ~loc
+        @@ List.map tdecls ~f:(fun { ptype_name = { txt } } ->
+             Typ.var ~loc (sprintf "alias_for_%s" txt))
+      in
+      List.fold_right
+        ys
+        ~init:(tup ~loc @@ List.map ys ~f:(fun (name, x, _) -> Typ.alias ~loc x name))
+        ~f:(fun (name, _, cls) acc -> Typ.arrow ~loc (Typ.arrow ~loc fix_arg cls) acc)
   ;;
 
   let fix_sig ~loc tdecls =
@@ -863,16 +909,16 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
                           ~loc
                           (Exp.sprintf ~loc "%s0" tdecl.ptype_name.txt)
                           ((Exp.tuple ~loc
-                           @@ List.map tdecls ~f:(fun { ptype_name = { txt } } ->
-                                Exp.sprintf ~loc "trait%s" txt))
-                          :: map_type_param_names tdecl.ptype_params ~f:(fun txt ->
-                               Exp.sprintf ~loc "f%s" txt)
-                             (* @
-                              * [Exp.app_list ~loc
-                              *    (Exp.sprintf ~loc "trait%s" tdecl.ptype_name.txt)
-                              *    (map_type_param_names tdecl.ptype_params
-                              *       ~f:(fun txt -> Exp.sprintf ~loc "f%s" txt))
-                              * ] *))
+                            @@ List.map tdecls ~f:(fun { ptype_name = { txt } } ->
+                                 Exp.sprintf ~loc "trait%s" txt))
+                           :: map_type_param_names tdecl.ptype_params ~f:(fun txt ->
+                                Exp.sprintf ~loc "f%s" txt)
+                              (* @
+                               * [Exp.app_list ~loc
+                               *    (Exp.sprintf ~loc "trait%s" tdecl.ptype_name.txt)
+                               *    (map_type_param_names tdecl.ptype_params
+                               *       ~f:(fun txt -> Exp.sprintf ~loc "f%s" txt))
+                               * ] *))
                       ; Exp.ident ~loc "inh"
                       ; Exp.ident ~loc "subj"
                       ]
@@ -949,6 +995,7 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
   ;;
 
   let do_mutual_types_sig ~loc sis plugins tdecls =
+    (* let tdecls = sort_decls tdecls |> List.rev in *)
     (* TODO: it could be a bug with topological sorting here *)
     sis
     @ List.concat_map tdecls ~f:(fun tdecl ->
@@ -1009,8 +1056,9 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
     | Recursive, [ tdecl ] -> do_typ_sig si ~loc plugins true tdecl
     | Recursive, ts ->
       (* Stdio.printf "Got %d declarations\n%!" (List.length ts); *)
-      do_mutual_types_sig ~loc si plugins ts
-    | Nonrecursive, tdls -> List.concat_map ~f:(do_typ_sig ~loc si plugins false) tdls
+      do_mutual_types_sig ~loc si plugins (sort_decls ts)
+    | Nonrecursive, tdls ->
+      List.concat_map ~f:(do_typ_sig ~loc si plugins false) (sort_decls tdls)
   ;;
 
   let str_type_decl_many_plugins ~loc si plugins_info declaration =
@@ -1021,7 +1069,7 @@ module Make (AstHelpers : GTHELPERS_sig.S) = struct
     match declaration with
     | Recursive, [] -> []
     | Recursive, [ tdecl ] -> do_typ ~loc si plugins true tdecl
-    | Recursive, ts -> do_mutual_types ~loc si plugins ts
+    | Recursive, ts -> do_mutual_types ~loc si plugins (sort_decls ts)
     | Nonrecursive, decls -> List.concat_map ~f:(do_typ ~loc si plugins false) decls
   ;;
 

--- a/common/naming.ml
+++ b/common/naming.ml
@@ -48,8 +48,12 @@ let init_trf_function trait s = trf_function trait s ^ "_0"
 let make_fix_name tdecls =
   (* Let's use only first type for fix function definition *)
   assert (List.length tdecls > 0);
-  let name = (List.hd tdecls).ptype_name.txt in
-  String.concat ~sep:"_" [ "fix"; name ]
+  let names =
+    tdecls
+    |> List.map ~f:(fun { ptype_name = { txt } } -> txt)
+    |> List.sort ~cmp:String.compare
+  in
+  String.concat ~sep:"_" ("fix" :: names)
 ;;
 
 let name_fix_generated_object ~plugin tdecl =

--- a/dune-project
+++ b/dune-project
@@ -28,6 +28,7 @@
   ocamlgraph
   logger-p5
   ppx_inline_test
+  bisect_ppx
   (ocaml
    (>= "4.13"))
   (ocaml-migrate-parsetree

--- a/plugins/dune
+++ b/plugins/dune
@@ -8,6 +8,8 @@
  (public_name GT.syntax.show)
  (modules show)
  (libraries GT.common)
+ (instrumentation
+  (backend bisect_ppx))
  (synopsis "Plugin 'show'"))
 
 (library

--- a/ppx/PpxHelpers.ml
+++ b/ppx/PpxHelpers.ml
@@ -100,6 +100,7 @@ module Exp = struct
 
   let from_caml e = e
   let ident ~loc s = pexp_ident ~loc @@ Located.lident ~loc s
+  let attribute attr e = { e with pexp_attributes = attr :: e.pexp_attributes }
   let of_longident ~loc l = pexp_ident ~loc (Located.mk ~loc l)
   let sprintf ~loc fmt = Printf.ksprintf (ident ~loc) fmt
   let unit ~loc = [%expr ()]
@@ -543,7 +544,7 @@ module Sig = struct
            (pmty_functor
               ~loc
               (Named (Located.mk ~loc (Some param), pmty_signature ~loc sigs))
-           @@ pmty_signature ~loc strs)
+            @@ pmty_signature ~loc strs)
   ;;
 
   let simple_gadt

--- a/regression/.ocamlformat
+++ b/regression/.ocamlformat
@@ -1,0 +1,4 @@
+profile=janestreet
+max-indent=2
+sequence-style = terminator
+field-space=loose

--- a/regression/827.t
+++ b/regression/827.t
@@ -1,0 +1,122 @@
+  $ ../ppx/pp_gt.exe -pretty test827mut.ml
+  class virtual ['ia,'a,'sa,'inh,'syn] list_t =
+    object
+      method virtual  c_Nil : 'inh -> 'syn
+      method virtual  c_Cons : 'inh -> 'a -> 'a list -> 'syn
+    end
+  let gcata_list tr inh s =
+    match s with | [] -> tr#c_Nil inh | x::xs -> tr#c_Cons inh x xs
+  class ['a,'sa,'syn] gmap_list_t fa  fself =
+    object
+      constraint 'syn = 'sa list
+      inherit  [unit,'a,'sa,unit,'syn] list_t
+      method c_Nil _ = []
+      method c_Cons _ x xs = (fa () x) :: (fself () xs)
+    end
+  class virtual ['ia,'a,'sa,'inh,'syn] option_t =
+    object
+      method virtual  c_None : 'inh -> 'syn
+      method virtual  c_Some : 'inh -> 'a -> 'syn
+    end
+  let gcata_option tr inh subj =
+    match subj with | None -> tr#c_None inh | Some x -> tr#c_Some inh x
+  class ['a,'sa,'syn] gmap_option_t fa  _fself =
+    object
+      constraint 'syn = 'sa option
+      inherit  [unit,'a,'sa,unit,'syn] option_t
+      method c_None () = None
+      method c_Some () x = Some (fa () x)
+    end
+  type 'a bbb =
+    | AAA of 'a * 'a bbb GT.list 
+  and 'a aaa =
+    | BBB of 'a * 'a bbb GT.option [@@deriving gt ~options:{ gmap }]
+  include
+    struct
+      class virtual ['ia,'a,'sa,'inh,'extra,'syn] aaa_t =
+        object
+          method virtual  c_BBB :
+            'inh -> 'extra -> 'a -> 'a bbb GT.option -> 'syn
+        end
+      class virtual ['ia,'a,'sa,'inh,'extra,'syn] bbb_t =
+        object
+          method virtual  c_AAA :
+            'inh -> 'extra -> 'a -> 'a bbb GT.list -> 'syn
+        end
+      let gcata_aaa (tr : (_,'typ0__003_,_,_,'typ0__003_ aaa,_)#aaa_t) inh subj
+        =
+        match subj with
+        | BBB (_x__001_, _x__002_) -> tr#c_BBB inh subj _x__001_ _x__002_
+      let gcata_bbb (tr : (_,'typ0__006_,_,_,'typ0__006_ bbb,_)#bbb_t) inh subj
+        =
+        match subj with
+        | AAA (_x__004_, _x__005_) -> tr#c_AAA inh subj _x__004_ _x__005_
+      let fix_aaa_bbb aaa0 bbb0 =
+        let rec traitaaa fa inh subj =
+          gcata_aaa (aaa0 (traitaaa, traitbbb) fa) inh subj
+        and traitbbb fa inh subj =
+          gcata_bbb (bbb0 (traitaaa, traitbbb) fa) inh subj in
+        (traitaaa, traitbbb)
+      class ['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t_stub ((_fself_aaa,
+                                                            gmap_bbb) as
+                                                             _mutuals_pack)
+         fa =
+        object
+          inherit  [unit,'a,'a_2,unit,'extra_aaa,'a_2 aaa] aaa_t
+          constraint 'extra_aaa = 'a aaa
+          constraint 'syn_aaa = 'a_2 aaa
+          method c_BBB () _ _x__009_ _x__010_ =
+            BBB
+              ((fa () _x__009_),
+                ((fun () -> fun subj -> GT.gmap GT.option (gmap_bbb fa ()) subj)
+                   () _x__010_))
+        end
+      class ['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t_stub ((_, _fself_bbb) as
+                                                             _mutuals_pack)
+         fa =
+        object
+          inherit  [unit,'a,'a_2,unit,'extra_bbb,'a_2 bbb] bbb_t
+          constraint 'extra_bbb = 'a bbb
+          constraint 'syn_bbb = 'a_2 bbb
+          method c_AAA () _ _x__011_ _x__012_ =
+            AAA
+              ((fa () _x__011_),
+                ((fun () -> fun subj -> GT.gmap GT.list (_fself_bbb fa ()) subj)
+                   () _x__012_))
+        end
+      let gmap_aaa_0 = new gmap_aaa_t_stub
+      let gmap_bbb_0 = new gmap_bbb_t_stub
+      let gmap_aaa eta__007_ =
+        let (f, _) = fix_aaa_bbb gmap_aaa_0 gmap_bbb_0 in f eta__007_
+      let gmap_bbb eta__008_ =
+        let (_, f) = fix_aaa_bbb gmap_aaa_0 gmap_bbb_0 in f eta__008_
+      class ['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t _  fa =
+        object
+          inherit  ((['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t_stub)
+            (gmap_aaa, gmap_bbb) fa)
+        end
+      class ['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t _  fa =
+        object
+          inherit  ((['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t_stub)
+            (gmap_aaa, gmap_bbb) fa)
+        end
+      let aaa =
+        {
+          GT.gcata = gcata_aaa;
+          GT.fix = fix_aaa_bbb;
+          GT.plugins =
+            (object method gmap fa subj = gmap_aaa (GT.lift fa) () subj end)
+        }
+      let gmap_aaa fa subj = gmap_aaa (GT.lift fa) () subj
+      let bbb =
+        {
+          GT.gcata = gcata_bbb;
+          GT.fix = fix_aaa_bbb;
+          GT.plugins =
+            (object method gmap fa subj = gmap_bbb (GT.lift fa) () subj end)
+        }
+      let gmap_bbb fa subj = gmap_bbb (GT.lift fa) () subj
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  let __ (type a) (type b) =
+    (fun eta -> GT.gmap bbb eta : (a -> b) -> a bbb -> b bbb)
+  $ ./test827mut.exe

--- a/regression/830.t
+++ b/regression/830.t
@@ -1,0 +1,122 @@
+  $ ../ppx/pp_gt.exe -pretty test827mut.ml
+  class virtual ['ia,'a,'sa,'inh,'syn] list_t =
+    object
+      method virtual  c_Nil : 'inh -> 'syn
+      method virtual  c_Cons : 'inh -> 'a -> 'a list -> 'syn
+    end
+  let gcata_list tr inh s =
+    match s with | [] -> tr#c_Nil inh | x::xs -> tr#c_Cons inh x xs
+  class ['a,'sa,'syn] gmap_list_t fa  fself =
+    object
+      constraint 'syn = 'sa list
+      inherit  [unit,'a,'sa,unit,'syn] list_t
+      method c_Nil _ = []
+      method c_Cons _ x xs = (fa () x) :: (fself () xs)
+    end
+  class virtual ['ia,'a,'sa,'inh,'syn] option_t =
+    object
+      method virtual  c_None : 'inh -> 'syn
+      method virtual  c_Some : 'inh -> 'a -> 'syn
+    end
+  let gcata_option tr inh subj =
+    match subj with | None -> tr#c_None inh | Some x -> tr#c_Some inh x
+  class ['a,'sa,'syn] gmap_option_t fa  _fself =
+    object
+      constraint 'syn = 'sa option
+      inherit  [unit,'a,'sa,unit,'syn] option_t
+      method c_None () = None
+      method c_Some () x = Some (fa () x)
+    end
+  type 'a bbb =
+    | AAA of 'a * 'a bbb GT.list 
+  and 'a aaa =
+    | BBB of 'a * 'a bbb GT.option [@@deriving gt ~options:{ gmap }]
+  include
+    struct
+      class virtual ['ia,'a,'sa,'inh,'extra,'syn] aaa_t =
+        object
+          method virtual  c_BBB :
+            'inh -> 'extra -> 'a -> 'a bbb GT.option -> 'syn
+        end
+      class virtual ['ia,'a,'sa,'inh,'extra,'syn] bbb_t =
+        object
+          method virtual  c_AAA :
+            'inh -> 'extra -> 'a -> 'a bbb GT.list -> 'syn
+        end
+      let gcata_aaa (tr : (_,'typ0__003_,_,_,'typ0__003_ aaa,_)#aaa_t) inh subj
+        =
+        match subj with
+        | BBB (_x__001_, _x__002_) -> tr#c_BBB inh subj _x__001_ _x__002_
+      let gcata_bbb (tr : (_,'typ0__006_,_,_,'typ0__006_ bbb,_)#bbb_t) inh subj
+        =
+        match subj with
+        | AAA (_x__004_, _x__005_) -> tr#c_AAA inh subj _x__004_ _x__005_
+      let fix_aaa_bbb aaa0 bbb0 =
+        let rec traitaaa fa inh subj =
+          gcata_aaa (aaa0 (traitaaa, traitbbb) fa) inh subj
+        and traitbbb fa inh subj =
+          gcata_bbb (bbb0 (traitaaa, traitbbb) fa) inh subj in
+        (traitaaa, traitbbb)
+      class ['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t_stub ((_fself_aaa,
+                                                            gmap_bbb) as
+                                                             _mutuals_pack)
+         fa =
+        object
+          inherit  [unit,'a,'a_2,unit,'extra_aaa,'a_2 aaa] aaa_t
+          constraint 'extra_aaa = 'a aaa
+          constraint 'syn_aaa = 'a_2 aaa
+          method c_BBB () _ _x__009_ _x__010_ =
+            BBB
+              ((fa () _x__009_),
+                ((fun () -> fun subj -> GT.gmap GT.option (gmap_bbb fa ()) subj)
+                   () _x__010_))
+        end
+      class ['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t_stub ((_, _fself_bbb) as
+                                                             _mutuals_pack)
+         fa =
+        object
+          inherit  [unit,'a,'a_2,unit,'extra_bbb,'a_2 bbb] bbb_t
+          constraint 'extra_bbb = 'a bbb
+          constraint 'syn_bbb = 'a_2 bbb
+          method c_AAA () _ _x__011_ _x__012_ =
+            AAA
+              ((fa () _x__011_),
+                ((fun () -> fun subj -> GT.gmap GT.list (_fself_bbb fa ()) subj)
+                   () _x__012_))
+        end
+      let gmap_aaa_0 = new gmap_aaa_t_stub
+      let gmap_bbb_0 = new gmap_bbb_t_stub
+      let gmap_aaa eta__007_ =
+        let (f, _) = fix_aaa_bbb gmap_aaa_0 gmap_bbb_0 in f eta__007_
+      let gmap_bbb eta__008_ =
+        let (_, f) = fix_aaa_bbb gmap_aaa_0 gmap_bbb_0 in f eta__008_
+      class ['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t _  fa =
+        object
+          inherit  ((['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t_stub)
+            (gmap_aaa, gmap_bbb) fa)
+        end
+      class ['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t _  fa =
+        object
+          inherit  ((['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t_stub)
+            (gmap_aaa, gmap_bbb) fa)
+        end
+      let aaa =
+        {
+          GT.gcata = gcata_aaa;
+          GT.fix = fix_aaa_bbb;
+          GT.plugins =
+            (object method gmap fa subj = gmap_aaa (GT.lift fa) () subj end)
+        }
+      let gmap_aaa fa subj = gmap_aaa (GT.lift fa) () subj
+      let bbb =
+        {
+          GT.gcata = gcata_bbb;
+          GT.fix = fix_aaa_bbb;
+          GT.plugins =
+            (object method gmap fa subj = gmap_bbb (GT.lift fa) () subj end)
+        }
+      let gmap_bbb fa subj = gmap_bbb (GT.lift fa) () subj
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  let __ (type a) (type b) =
+    (fun eta -> GT.gmap bbb eta : (a -> b) -> a bbb -> b bbb)
+  $ ./test827mut.exe

--- a/regression/dune
+++ b/regression/dune
@@ -6,4 +6,52 @@
 (include dune.tests)
 
 (cram
- (deps ../ppx/pp_gt.exe test824mut.ml))
+ (applies_to test828)
+ (deps
+  ../ppx/pp_gt.exe
+  test828mut.ml
+  test828mut.exe
+  ;
+  ))
+
+; TODO outogenerate proper cram dependencies
+; (cram
+;  (applies_to * \ foo bar)
+;  (deps ../foo.exe))
+
+(cram
+ (deps
+  ../ppx/pp_gt.exe
+  test824mut.ml
+  test827mut.ml
+  test827mut.exe
+  test830mut.exe
+  ;
+  ))
+
+(executable
+ (name test827mut)
+ (modules test827mut)
+ (libraries GT)
+ (flags
+  (:standard
+   ;-dsource
+   ;-rectypes
+   ))
+ (preprocess
+  (action
+   (run %{project_root}/ppx/pp_gt.exe -pretty --as-pp %{input-file})))
+ (preprocessor_deps
+  (file %{project_root}/ppx/pp_gt.exe)))
+
+(executables
+ (names test830mut test828mut)
+ (modules test830mut test828mut)
+ (libraries GT)
+ (flags
+  (:standard -rectypes))
+ (preprocess
+  (action
+   (run %{project_root}/ppx/pp_gt.exe -pretty --as-pp %{input-file})))
+ (preprocessor_deps
+  (file %{project_root}/ppx/pp_gt.exe)))

--- a/regression/dune.tests
+++ b/regression/dune.tests
@@ -363,6 +363,8 @@
   (name test804polyvar)
   (modules test804polyvar)
   (libraries GT)
+  (flags (:standard ;-dsource 
+  ))
   (preprocess (action (run %{project_root}/ppx/pp_gt.exe --as-pp %{input-file})))
   (preprocessor_deps (file %{project_root}/ppx/pp_gt.exe)))
 
@@ -476,7 +478,7 @@
   (name test827)
   (modules test827)
   (libraries GT)
-  (flags (:standard -rectypes -dsource))
+  (flags (:standard -rectypes))
   (preprocess (action (run %{project_root}/ppx/pp_gt.exe -pretty --as-pp %{input-file})))
   (preprocessor_deps (file %{project_root}/ppx/pp_gt.exe)))
 

--- a/regression/test003.ml
+++ b/regression/test003.ml
@@ -12,7 +12,7 @@ class show_a2stub prereq =
     method! c_C () a ys = "new " ^ super#c_C () a ys
   end
 
-let show_a_new eta = let (f, _) = fix_a (new show_a2stub) show_b_0 in f eta
+let show_a_new eta = let (f, _) = fix_a_b (new show_a2stub) show_b_0 in f eta
 
 let a = { a with plugins = object
                    method show eta = show_a_new () eta
@@ -20,4 +20,3 @@ let a = { a with plugins = object
 let _ =
   Printf.printf "%s\n" (GT.show(b) y);
   Printf.printf "%s\n" (GT.show(a) x);
-

--- a/regression/test004.ml
+++ b/regression/test004.ml
@@ -17,7 +17,7 @@ class ['e] show_a' (for_a,for_b) =
 
 
 let show_a' () s =
-  (fst @@ fix_a (new show_a') (new show_b_t_stub)) () s
+  (fst @@ fix_a_b (new show_a') (new show_b_t_stub)) () s
 
 let () =
   Printf.printf "%s\n" (show_a' () x)

--- a/regression/test005.ml
+++ b/regression/test005.ml
@@ -21,10 +21,10 @@ module Show2 = struct
   let showb0 a = Printf.printf "new!\n"; new show_b_t_stub2 a
 
   let show_a () s =
-    (fst @@ fix_a showa0 showb0) () s
+    (fst @@ fix_a_b showa0 showb0) () s
 
   let show_b () s =
-    (snd @@ fix_a showa0 showb0) () s
+    (snd @@ fix_a_b showa0 showb0) () s
 
   let _ = Printf.printf "%s\n" (show_a () (`A (`B (`A (`D "4")))))
 end
@@ -50,7 +50,7 @@ module ShowC = struct
 
   class ['extra] show_c_stub2 make_clas =
     let show_a2,show_b2 =
-      Show2.(fix_a
+      Show2.(fix_a_b
                showa0
                (fun _ -> ((make_clas ()) (* :> 'extra show_b_t_stub *)) ))
     in

--- a/regression/test013.ml
+++ b/regression/test013.ml
@@ -17,7 +17,7 @@ class [ 'fself ] show_b' prereq =
     method! c_C () _ s = "new C " ^ s
   end
 
-let show_b_new eta = let (_,f) = fix_a (new show_a_t_stub) (new show_b') in f eta
+let show_b_new eta = let (_,f) = fix_a_b (new show_a_t_stub) (new show_b') in f eta
 
 let _ =
   let y = `D (`B (`C "5")) in

--- a/regression/test014.ml
+++ b/regression/test014.ml
@@ -10,7 +10,7 @@ class show_a_new ((_,fb,_) as prereq) =
   end
 
 let show_a_new eta =
-  let (f,_,_) = fix_a (new show_a_new) (new show_b_t_stub) (new show_c_t_stub) in
+  let (f,_,_) = fix_a_b_c (new show_a_new) (new show_b_t_stub) (new show_c_t_stub) in
   f eta
 
 

--- a/regression/test021.ml
+++ b/regression/test021.ml
@@ -17,7 +17,7 @@ end
  *             | Ishow_a.B -> GT.transform_gc gcata_b (new show_b_t f) :
  *             a)}) *)
 
-let show_a' s = (fst @@ fix_a (new show_a_t_stub2) (new show_b_t_stub)) () s
+let show_a' s = (fst @@ fix_a_b (new show_a_t_stub2) (new show_b_t_stub)) () s
 
 let _ =
   let x = `A (`B (`C [1; 2; 3; 4])) in

--- a/regression/test802mutal.ml
+++ b/regression/test802mutal.ml
@@ -1,66 +1,87 @@
 open Printf
 
-module PV: sig
-  type a = [`A of b | `C of GT.int   ]
-  and  b = [`B of a | `D of GT.string]
-  [@@deriving gt ~options:{show;gmap}]
-end = struct
-  type a = [`A of b | `C of GT.int   ]
-  and  b = [`B of a | `D of GT.string]
-  [@@deriving gt ~options:{show;gmap}]
-end
+module PV : sig
+  type a =
+    [ `A of b
+    | `C of GT.int
+    ]
 
+  and b =
+    [ `B of a
+    | `D of GT.string
+    ]
+  [@@deriving gt ~options:{ show; gmap }]
+end = struct
+  type a =
+    [ `A of b
+    | `C of GT.int
+    ]
+
+  and b =
+    [ `B of a
+    | `D of GT.string
+    ]
+  [@@deriving gt ~options:{ show; gmap }]
+end
 
 module Show2 = struct
   open PV
-  class ['self] show_b_t_stub2 (for_a,for_b) = object
-    inherit ['self] show_b_t_stub (for_a,for_b)
-    method c_C () (_ :b) a  = Printf.sprintf "new C (%s)" (for_a () a)
-    method! c_D () _ s  = Printf.sprintf "new D %s" s
-  end
 
-  let showa0 a = Printf.printf "new!\n"; new show_a_t_stub  a
-  let showb0 a = Printf.printf "new!\n"; new show_b_t_stub2 a
+  class ['self] show_b_t_stub2 (for_a, for_b) =
+    object
+      inherit ['self] show_b_t_stub (for_a, for_b)
+      method c_C () (_ : b) a = Printf.sprintf "new C (%s)" (for_a () a)
+      method! c_D () _ s = Printf.sprintf "new D %s" s
+    end
 
-  let show_a () s =
-    (fst @@ fix_a showa0 showb0) () s
+  let showa0 a =
+    Printf.printf "new!\n";
+    new show_a_t_stub a
+  ;;
 
-  let show_b () s =
-    (snd @@ fix_a showa0 showb0) () s
+  let showb0 a =
+    Printf.printf "new!\n";
+    new show_b_t_stub2 a
+  ;;
 
+  let show_a () s = (fst @@ fix_a_b showa0 showb0) () s
+  let show_b () s = (snd @@ fix_a_b showa0 showb0) () s
   let _ = Printf.printf "%s\n" (show_a () (`A (`B (`A (`D "4")))))
 end
 
-type c = [ PV.b | `E of GT.int ]
-[@@deriving gt ~options:{show}]
-
+type c =
+  [ PV.b
+  | `E of GT.int
+  ]
+[@@deriving gt ~options:{ show }]
 
 module ShowC = struct
   open PV
 
   class ['extra] show_c_stub2 make_clas =
-    let show_a2,show_b2 =
-      Show2.(fix_a
-               showa0
-               (fun _ -> ((make_clas ()) (* :> 'extra show_b_t_stub *)) ))
+    let show_a2, show_b2 =
+      Show2.(fix_a_b showa0 (fun _ -> make_clas () (* :> 'extra show_b_t_stub *)))
     in
     object
       inherit [unit, 'extra, string] c_t
-
-      inherit [ 'extra ] show_b_t_stub (show_a2,show_b2)
-      method! c_B () _ a  = sprintf "new `B (%s)" (show_a2 () a)
-      method! c_D () _ s  = sprintf "new `D %s" s
-      method  c_E () _ s  = sprintf "new `E %d" s
+      inherit ['extra] show_b_t_stub (show_a2, show_b2)
+      method! c_B () _ a = sprintf "new `B (%s)" (show_a2 () a)
+      method! c_D () _ s = sprintf "new `D %s" s
+      method c_E () _ s = sprintf "new `E %d" s
     end
 
-  let rec showc0 () = Printf.printf "new c0!\n"; new show_c_stub2 showc0
+  let rec showc0 () =
+    Printf.printf "new c0!\n";
+    new show_c_stub2 showc0
+  ;;
 
-  let show_c () (s: c) =
+  let show_c () (s : c) =
     let trait () s = gcata_c (showc0 ()) () (s :> c) in
     trait () s
+  ;;
 
   let _ =
     Printf.printf "%s\n" (show_c () (`B (`A (`D "4"))));
-    Printf.printf "%s\n" (show_c () (`E 18) )
-
+    Printf.printf "%s\n" (show_c () (`E 18))
+  ;;
 end

--- a/regression/test804polyvar.ml
+++ b/regression/test804polyvar.ml
@@ -1,35 +1,45 @@
-open GT
-
 module L : sig
-        type 'a list = [`Nil | `Cons of 'a * 'a list ]
-        [@@deriving gt ~options:{gmap }]
+  type 'a lst =
+    [ `Nil
+    | `Cons of 'a * 'a lst
+    ]
+  [@@deriving gt ~options:{ gmap }]
+end = struct
+  type 'a lst =
+    [ `Nil
+    | `Cons of 'a * 'a lst
+    ]
+  [@@deriving gt ~options:{ gmap }]
 
-end  = struct
-        type 'a list = [`Nil | `Cons of 'a * 'a list ]
-        [@@deriving gt ~options:{gmap }]
+  let __
+    :  (('inh -> 'c lst -> 'syn) -> ('e, 'c, 'f, 'inh, [> 'c lst ], 'syn) #lst_t) -> 'inh
+    -> 'c lst -> 'syn
+    =
+   fun eta -> GT.transform_gc gcata_lst eta
+ ;;
 end
 
-type 'a maybe = Just of 'a | Nothing
-[@@deriving gt ~options:{show; fmt }]
+type 'a maybe =
+  | Just of 'a
+  | Nothing
+[@@deriving gt ~options:{ show; fmt }]
 
-type 'a pv = [ `A of 'a ]
-[@@deriving gt ~options:{show; fmt}]
-
+type 'a pv = [ `A of 'a ] [@@deriving gt ~options:{ show; fmt }]
 
 let () =
   let sh x = GT.show pv Fun.id x in
   Printf.printf "%s\n%!" (sh @@ `A "aaa")
+;;
 
-
-include (struct
-  type 'a wtf = [ `C of 'a | 'a pv ] maybe
-  [@@deriving gt ~options:{show; fmt}]
-end (* : sig
-   type 'a wtf = [ `C of 'a | 'a pv ] maybe
-   [@@deriving gt ~options:{show; fmt}]
- end *)
-)
+include (
+  struct
+    type 'a wtf = [ `C of 'a | 'a pv ] maybe [@@deriving gt ~options:{ show; fmt }]
+  end :
+    sig
+      type 'a wtf = [ `C of 'a | 'a pv ] maybe [@@deriving gt ~options:{ show; fmt }]
+    end)
 
 let () =
   let sh x = GT.show wtf Fun.id x in
-  Printf.printf "%s\t%s\n%!" (sh @@ Just(`A "a")) (sh @@ Just (`C "ccc"))
+  Printf.printf "%s\t%s\n%!" (sh @@ Just (`A "a")) (sh @@ Just (`C "ccc"))
+;;

--- a/regression/test824.t
+++ b/regression/test824.t
@@ -142,7 +142,7 @@
       let _ = gcata_term
       let gcata_heap = gcata_t
       let _ = gcata_heap
-      let fix_api api0 pf0 t0 term0 heap0 =
+      let fix_api_heap_pf_t_term api0 pf0 t0 term0 heap0 =
         let rec traitapi inh subj =
           gcata_api (api0 (traitapi, traitpf, traitt, traitterm, traitheap))
             inh subj
@@ -159,7 +159,7 @@
           gcata_heap (heap0 (traitapi, traitpf, traitt, traitterm, traitheap))
             inh subj in
         (traitapi, traitpf, traitt, traitterm, traitheap)
-      let _ = fix_api
+      let _ = fix_api_heap_pf_t_term
       class ['extra_api] fmt_api_t_stub ((_fself_api, _, _, fmt_term, _) as
                                            _mutuals_pack)
         =
@@ -309,27 +309,32 @@
       let _ = fmt_heap_0
       let fmt_api eta__028_ =
         let (f, _, _, _, _) =
-          fix_api fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0 fmt_heap_0 in
+          fix_api_heap_pf_t_term fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0
+            fmt_heap_0 in
         f eta__028_
       let _ = fmt_api
       let fmt_pf eta__029_ =
         let (_, f, _, _, _) =
-          fix_api fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0 fmt_heap_0 in
+          fix_api_heap_pf_t_term fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0
+            fmt_heap_0 in
         f eta__029_
       let _ = fmt_pf
       let fmt_t eta__030_ =
         let (_, _, f, _, _) =
-          fix_api fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0 fmt_heap_0 in
+          fix_api_heap_pf_t_term fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0
+            fmt_heap_0 in
         f eta__030_
       let _ = fmt_t
       let fmt_term eta__031_ =
         let (_, _, _, f, _) =
-          fix_api fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0 fmt_heap_0 in
+          fix_api_heap_pf_t_term fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0
+            fmt_heap_0 in
         f eta__031_
       let _ = fmt_term
       let fmt_heap eta__032_ =
         let (_, _, _, _, f) =
-          fix_api fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0 fmt_heap_0 in
+          fix_api_heap_pf_t_term fmt_api_0 fmt_pf_0 fmt_t_0 fmt_term_0
+            fmt_heap_0 in
         f eta__032_
       let _ = fmt_heap
       class ['extra_api] fmt_api_t _ =
@@ -360,35 +365,35 @@
       let api =
         {
           GT.gcata = gcata_api;
-          GT.fix = fix_api;
+          GT.fix = fix_api_heap_pf_t_term;
           GT.plugins = (object method fmt = fmt_api end)
         }
       let _ = api
       let pf =
         {
           GT.gcata = gcata_pf;
-          GT.fix = fix_api;
+          GT.fix = fix_api_heap_pf_t_term;
           GT.plugins = (object method fmt = fmt_pf end)
         }
       let _ = pf
       let t =
         {
           GT.gcata = gcata_t;
-          GT.fix = fix_api;
+          GT.fix = fix_api_heap_pf_t_term;
           GT.plugins = (object method fmt = fmt_t end)
         }
       let _ = t
       let term =
         {
           GT.gcata = gcata_term;
-          GT.fix = fix_api;
+          GT.fix = fix_api_heap_pf_t_term;
           GT.plugins = (object method fmt = fmt_term end)
         }
       let _ = term
       let heap =
         {
           GT.gcata = gcata_heap;
-          GT.fix = fix_api;
+          GT.fix = fix_api_heap_pf_t_term;
           GT.plugins = (object method fmt = fmt_heap end)
         }
       let _ = heap

--- a/regression/test827mut.ml
+++ b/regression/test827mut.ml
@@ -1,0 +1,44 @@
+class virtual ['ia, 'a, 'sa, 'inh, 'syn] list_t =
+  object
+    method virtual c_Nil : 'inh -> 'syn
+    method virtual c_Cons : 'inh -> 'a -> 'a list -> 'syn
+  end
+
+let gcata_list tr inh s =
+  match s with
+  | [] -> tr#c_Nil inh
+  | x :: xs -> tr#c_Cons inh x xs
+;;
+
+class ['a, 'sa, 'syn] gmap_list_t fa fself =
+  object
+    constraint 'syn = 'sa list
+    inherit [unit, 'a, 'sa, unit, 'syn] list_t
+    method c_Nil _ = []
+    method c_Cons _ x xs = fa () x :: fself () xs
+  end
+
+class virtual ['ia, 'a, 'sa, 'inh, 'syn] option_t =
+  object
+    method virtual c_None : 'inh -> 'syn
+    method virtual c_Some : 'inh -> 'a -> 'syn
+  end
+
+let gcata_option tr inh subj =
+  match subj with
+  | None -> tr#c_None inh
+  | Some x -> tr#c_Some inh x
+;;
+
+class ['a, 'sa, 'syn] gmap_option_t fa _fself =
+  object
+    constraint 'syn = 'sa option
+    inherit [unit, 'a, 'sa, unit, 'syn] option_t
+    method c_None () = None
+    method c_Some () x = Some (fa () x)
+  end
+
+type 'a bbb = AAA of 'a * 'a bbb GT.list
+and 'a aaa = BBB of 'a * 'a bbb GT.option [@@deriving gt ~options:{ gmap }]
+
+let __ (type a b) : (a -> b) -> a bbb -> b bbb = fun eta -> GT.gmap bbb eta

--- a/regression/test828.t
+++ b/regression/test828.t
@@ -1,0 +1,219 @@
+  $ ../ppx/pp_gt.exe -pretty test828mut.ml
+  class virtual ['ia,'a,'sa,'inh,'syn] list_t =
+    object
+      method virtual  c_Nil : 'inh -> 'syn
+      method virtual  c_Cons : 'inh -> 'a -> 'a list -> 'syn
+    end
+  let gcata_list tr inh s =
+    match s with | [] -> tr#c_Nil inh | x::xs -> tr#c_Cons inh x xs
+  class ['a,'sa,'syn] gmap_list_t fa  fself =
+    object
+      constraint 'syn = 'sa list
+      inherit  [unit,'a,'sa,unit,'syn] list_t
+      method c_Nil _ = []
+      method c_Cons _ x xs = (fa () x) :: (fself () xs)
+    end
+  class virtual ['ia,'a,'sa,'inh,'syn] option_t =
+    object
+      method virtual  c_None : 'inh -> 'syn
+      method virtual  c_Some : 'inh -> 'a -> 'syn
+    end
+  let gcata_option tr inh subj =
+    match subj with | None -> tr#c_None inh | Some x -> tr#c_Some inh x
+  class ['a,'sa,'syn] gmap_option_t fa  _fself =
+    object
+      constraint 'syn = 'sa option
+      inherit  [unit,'a,'sa,unit,'syn] option_t
+      method c_None () = None
+      method c_Some () x = Some (fa () x)
+    end
+  include
+    (struct
+       type 'a aaa = 'a bbb GT.option
+       and 'a bbb = 'a bbb GT.list[@@deriving gt ~options:{ gmap }]
+       include
+         struct
+           class virtual ['ia,'a,'sa,'inh,'extra,'syn] aaa_t =
+             object
+               inherit  ['ia bbb,'a bbb,'sa bbb,'inh,'extra,'syn] GT.option_t
+             end
+           class virtual ['ia,'a,'sa,'inh,'extra,'syn] bbb_t =
+             object
+               inherit  ['ia bbb,'a bbb,'sa bbb,'inh,'extra,'syn] GT.list_t
+             end
+           let gcata_aaa = GT.gcata_option
+           let gcata_bbb = GT.gcata_list
+           let fix_aaa_bbb aaa0 bbb0 =
+             let rec traitaaa fa inh subj =
+               gcata_aaa (aaa0 (traitaaa, traitbbb) fa) inh subj
+             and traitbbb fa inh subj =
+               gcata_bbb (bbb0 (traitaaa, traitbbb) fa) inh subj in
+             (traitaaa, traitbbb)
+           class ['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t_stub ((_fself_aaa,
+                                                                 gmap_bbb) as
+                                                                  _mutuals_pack)
+              fa =
+             object
+               inherit  [unit,'a,'a_2,unit,'extra_aaa,'a_2 aaa] aaa_t
+               constraint 'extra_aaa = 'a aaa
+               constraint 'syn_aaa = 'a_2 aaa
+               inherit  ((['a bbb,'a_2 bbb,'extra_aaa,'syn_aaa]
+                 GT.gmap_option_t) (gmap_bbb fa) (_fself_aaa fa))
+             end
+           class ['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t_stub ((_, _fself_bbb)
+                                                                  as
+                                                                  _mutuals_pack)
+              fa =
+             object
+               inherit  [unit,'a,'a_2,unit,'extra_bbb,'a_2 bbb] bbb_t
+               constraint 'extra_bbb = 'a bbb
+               constraint 'syn_bbb = 'a_2 bbb
+               inherit  ((['a bbb,'a_2 bbb,'extra_bbb,'syn_bbb] GT.gmap_list_t)
+                 (_fself_bbb fa) (_fself_bbb fa))
+             end
+           let gmap_aaa_0 = new gmap_aaa_t_stub
+           let gmap_bbb_0 = new gmap_bbb_t_stub
+           let gmap_aaa eta__001_ =
+             let (f, _) = fix_aaa_bbb gmap_aaa_0 gmap_bbb_0 in f eta__001_
+           let gmap_bbb eta__002_ =
+             let (_, f) = fix_aaa_bbb gmap_aaa_0 gmap_bbb_0 in f eta__002_
+           class ['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t _  fa =
+             object
+               inherit  ((['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t_stub)
+                 (gmap_aaa, gmap_bbb) fa)
+             end
+           class ['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t _  fa =
+             object
+               inherit  ((['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t_stub)
+                 (gmap_aaa, gmap_bbb) fa)
+             end
+           let aaa =
+             {
+               GT.gcata = gcata_aaa;
+               GT.fix = fix_aaa_bbb;
+               GT.plugins =
+                 (object method gmap fa subj = gmap_aaa (GT.lift fa) () subj
+                  end)
+             }
+           let gmap_aaa fa subj = gmap_aaa (GT.lift fa) () subj
+           let bbb =
+             {
+               GT.gcata = gcata_bbb;
+               GT.fix = fix_aaa_bbb;
+               GT.plugins =
+                 (object method gmap fa subj = gmap_bbb (GT.lift fa) () subj
+                  end)
+             }
+           let gmap_bbb fa subj = gmap_bbb (GT.lift fa) () subj
+         end[@@ocaml.doc "@inline"][@@merlin.hide ]
+       let __ (type a) (type b) =
+         (fun eta -> GT.gmap bbb eta : (a -> b) -> a bbb -> b bbb)
+     end :
+      sig
+        type 'a aaa = 'a bbb GT.option
+        and 'a bbb = 'a bbb GT.list[@@deriving gt ~options:{ gmap }]
+        include
+          sig
+            class virtual ['ia,'a,'sa,'inh,'extra,'syn] aaa_t :
+              object
+                inherit ['ia bbb,'a bbb,'sa bbb,'inh,'extra,'syn] GT.option_t
+              end
+            val gcata_aaa :
+              (_,'a,'sa,'inh,'a aaa,'syn)#aaa_t -> 'inh -> 'a aaa -> 'syn
+            class virtual ['ia,'a,'sa,'inh,'extra,'syn] bbb_t :
+              object
+                inherit ['ia bbb,'a bbb,'sa bbb,'inh,'extra,'syn] GT.list_t
+              end
+            val gcata_bbb :
+              (_,'a,'sa,'inh,'a bbb,'syn)#bbb_t -> 'inh -> 'a bbb -> 'syn
+            val fix_aaa_bbb :
+              (('alias_for_aaa * 'alias_for_bbb) ->
+                 ('a1_i -> 'a1 -> 'a1_s) ->
+                   ('a1_i,'a1,'a1_s,'inh2,'a1 aaa,'syn3)#aaa_t)
+                ->
+                (('alias_for_aaa * 'alias_for_bbb) ->
+                   ('a4_i -> 'a4 -> 'a4_s) ->
+                     ('a4_i,'a4,'a4_s,'inh5,'a4 bbb,'syn6)#bbb_t)
+                  ->
+                  (((('a1_i -> 'a1 -> 'a1_s) -> 'inh2 -> 'a1 aaa -> 'syn3) as
+                      'alias_for_aaa)
+                    *
+                    ((('a4_i -> 'a4 -> 'a4_s) -> 'inh5 -> 'a4 bbb -> 'syn6) as
+                       'alias_for_bbb))
+            class ['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t_stub :
+              (((unit -> 'a -> 'a_2) -> unit -> 'a aaa -> 'a_2 aaa) *
+                ((unit -> 'a -> 'a_2) -> unit -> 'a bbb -> 'a_2 bbb)) ->
+                (unit -> 'a -> 'a_2) ->
+                  object
+                    constraint 'extra_aaa = 'a aaa
+                    constraint 'syn_aaa = 'a_2 aaa
+                    inherit ['a bbb,'a_2 bbb,'extra_aaa,'syn_aaa]
+                      GT.gmap_option_t
+                  end
+            class ['a,'a_2,'extra_aaa,'syn_aaa] gmap_aaa_t :
+              (unit -> 'a -> 'a_2) ->
+                (unit -> 'a aaa -> 'a_2 aaa) ->
+                  object
+                    constraint 'extra_aaa = 'a aaa
+                    constraint 'syn_aaa = 'a_2 aaa
+                    inherit ['a bbb,'a_2 bbb,'extra_aaa,'syn_aaa]
+                      GT.gmap_option_t
+                  end
+            class ['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t_stub :
+              (((unit -> 'a -> 'a_2) -> unit -> 'a aaa -> 'a_2 aaa) *
+                ((unit -> 'a -> 'a_2) -> unit -> 'a bbb -> 'a_2 bbb)) ->
+                (unit -> 'a -> 'a_2) ->
+                  object
+                    constraint 'extra_bbb = 'a bbb
+                    constraint 'syn_bbb = 'a_2 bbb
+                    inherit ['a bbb,'a_2 bbb,'extra_bbb,'syn_bbb]
+                      GT.gmap_list_t
+                  end
+            class ['a,'a_2,'extra_bbb,'syn_bbb] gmap_bbb_t :
+              (unit -> 'a -> 'a_2) ->
+                (unit -> 'a bbb -> 'a_2 bbb) ->
+                  object
+                    constraint 'extra_bbb = 'a bbb
+                    constraint 'syn_bbb = 'a_2 bbb
+                    inherit ['a bbb,'a_2 bbb,'extra_bbb,'syn_bbb]
+                      GT.gmap_list_t
+                  end
+            val gmap_aaa : ('a -> 'a_2) -> 'a aaa -> 'a_2 aaa
+            val gmap_bbb : ('a -> 'a_2) -> 'a bbb -> 'a_2 bbb
+            val aaa :
+              ((_,'a,'sa,'inh,'a aaa,'syn)#aaa_t -> 'inh -> 'a aaa -> 'syn,
+                < gmap: ('a -> 'a_2) -> 'a aaa -> 'a_2 aaa   > ,
+                (('alias_for_aaa * 'alias_for_bbb) ->
+                   ('a1_i -> 'a1 -> 'a1_s) ->
+                     ('a1_i,'a1,'a1_s,'inh2,'a1 aaa,'syn3)#aaa_t)
+                  ->
+                  (('alias_for_aaa * 'alias_for_bbb) ->
+                     ('a4_i -> 'a4 -> 'a4_s) ->
+                       ('a4_i,'a4,'a4_s,'inh5,'a4 bbb,'syn6)#bbb_t)
+                    ->
+                    (((('a1_i -> 'a1 -> 'a1_s) -> 'inh2 -> 'a1 aaa -> 'syn3) as
+                        'alias_for_aaa)
+                      *
+                      ((('a4_i -> 'a4 -> 'a4_s) -> 'inh5 -> 'a4 bbb -> 'syn6)
+                         as 'alias_for_bbb)))
+                GT.t
+            val bbb :
+              ((_,'a,'sa,'inh,'a bbb,'syn)#bbb_t -> 'inh -> 'a bbb -> 'syn,
+                < gmap: ('a -> 'a_2) -> 'a bbb -> 'a_2 bbb   > ,
+                (('alias_for_aaa * 'alias_for_bbb) ->
+                   ('a1_i -> 'a1 -> 'a1_s) ->
+                     ('a1_i,'a1,'a1_s,'inh2,'a1 aaa,'syn3)#aaa_t)
+                  ->
+                  (('alias_for_aaa * 'alias_for_bbb) ->
+                     ('a4_i -> 'a4 -> 'a4_s) ->
+                       ('a4_i,'a4,'a4_s,'inh5,'a4 bbb,'syn6)#bbb_t)
+                    ->
+                    (((('a1_i -> 'a1 -> 'a1_s) -> 'inh2 -> 'a1 aaa -> 'syn3) as
+                        'alias_for_aaa)
+                      *
+                      ((('a4_i -> 'a4 -> 'a4_s) -> 'inh5 -> 'a4 bbb -> 'syn6)
+                         as 'alias_for_bbb)))
+                GT.t
+          end[@@ocaml.doc "@inline"][@@merlin.hide ]
+      end)
+  $ ./test828mut.exe

--- a/regression/test828mut.ml
+++ b/regression/test828mut.ml
@@ -1,0 +1,51 @@
+class virtual ['ia, 'a, 'sa, 'inh, 'syn] list_t =
+  object
+    method virtual c_Nil : 'inh -> 'syn
+    method virtual c_Cons : 'inh -> 'a -> 'a list -> 'syn
+  end
+
+let gcata_list tr inh s =
+  match s with
+  | [] -> tr#c_Nil inh
+  | x :: xs -> tr#c_Cons inh x xs
+;;
+
+class ['a, 'sa, 'syn] gmap_list_t fa fself =
+  object
+    constraint 'syn = 'sa list
+    inherit [unit, 'a, 'sa, unit, 'syn] list_t
+    method c_Nil _ = []
+    method c_Cons _ x xs = fa () x :: fself () xs
+  end
+
+class virtual ['ia, 'a, 'sa, 'inh, 'syn] option_t =
+  object
+    method virtual c_None : 'inh -> 'syn
+    method virtual c_Some : 'inh -> 'a -> 'syn
+  end
+
+let gcata_option tr inh subj =
+  match subj with
+  | None -> tr#c_None inh
+  | Some x -> tr#c_Some inh x
+;;
+
+class ['a, 'sa, 'syn] gmap_option_t fa _fself =
+  object
+    constraint 'syn = 'sa option
+    inherit [unit, 'a, 'sa, unit, 'syn] option_t
+    method c_None () = None
+    method c_Some () x = Some (fa () x)
+  end
+
+include (
+  struct
+    type 'a aaa = 'a bbb GT.option
+    and 'a bbb = 'a bbb GT.list [@@deriving gt ~options:{ gmap }]
+
+    let __ (type a b) : (a -> b) -> a bbb -> b bbb = fun eta -> GT.gmap bbb eta
+  end :
+    sig
+      type 'a aaa = 'a bbb GT.option
+      and 'a bbb = 'a bbb GT.list [@@deriving gt ~options:{ gmap }]
+    end)

--- a/regression/test830mut.ml
+++ b/regression/test830mut.ml
@@ -1,0 +1,38 @@
+type 'a logic =
+  | Var
+  | Value of 'a
+[@@deriving gt ~options:{ gmap }]
+(*
+type nonrec ('a, 'a0) targ_fuly = T of 'a0 * 'a [@@deriving gt ~options:{ gmap }]
+
+type nonrec ('a, 'a1, 'a0) jtyp_fuly =
+  | Array of 'a1
+  | V of 'a0
+[@@deriving gt ~options:{ gmap }]
+
+type 'a targ_logic = ('a, 'a jtyp_logic) targ_fuly logic
+
+and 'a jtyp_logic = ('a, 'a jtyp_logic, 'a targ_logic) jtyp_fuly logic
+[@@deriving gt ~options:{ gmap }]
+
+let (_ : ('a -> 'b) -> 'a targ_logic -> 'b targ_logic) = fun eta -> GT.gmap targ_logic eta
+
+let __ : 'a 'b. ('a -> 'b) -> 'a jtyp_logic -> 'b jtyp_logic =
+ fun eta -> GT.gmap jtyp_logic eta
+;; *)
+
+type nonrec ('a, 'a0) targ_fuly = T of 'a0 * 'a [@@deriving gt ~options:{ gmap }]
+
+type nonrec ('a, 'a1, 'a0) jtyp_fuly =
+  | Array of 'a1
+  | V of 'a0
+[@@deriving gt ~options:{ gmap }]
+
+type 'a targ_logic = ('a, 'a jtyp_logic) targ_fuly logic
+
+and 'a jtyp_logic = ('a, 'a jtyp_logic, 'a targ_logic) jtyp_fuly logic
+[@@deriving gt ~options:{ gmap }]
+
+let __ (type a b) : (a -> b) -> a jtyp_logic -> b jtyp_logic =
+ fun eta -> GT.gmap jtyp_logic eta
+;;


### PR DESCRIPTION
Now the test below should work
```
    type 'a aaa = 'a bbb GT.option
    and 'a bbb = 'a bbb GT.list [@@deriving gt ~options:{ gmap }]

```